### PR TITLE
Start #8, add a simple alt attribute to img

### DIFF
--- a/addon/emailTemplates.jsx
+++ b/addon/emailTemplates.jsx
@@ -30,9 +30,16 @@ this.emailTemplates = (function () {
       if (tab.screenshot) {
         // Note: the alt attribute is searched by gmail, but the title attribute is NOT searched
         // Note: box-shadow is specifically filtered out by gmail, other styles may get through
+        let imgAlt = "Screenshot";
+        let domain = (new URL(tab.url)).hostname;
+        if (domain) {
+          // If it doesn't have a domain, it's probably a file: URL, or something non-standard
+          domain = domain.replace(/^www\d?\./i, "");
+          imgAlt = `Screenshot of ${domain}`;
+        }
         img = <section>
           <div style={{display: "inline-block", boxShadow: "7px 7px 20px #999", border: "1px solid #999"}}>
-            <img height={tab.screenshot.height} width={tab.screenshot.width} src={tab.screenshot.url} />
+            <img height={tab.screenshot.height} width={tab.screenshot.width} src={tab.screenshot.url} alt={imgAlt} />
           </div>
           <br />
         </section>;


### PR DESCRIPTION
We want to do something fancier later, but I want to include an alt attribute now so we can be sure it stays stable through the paste process