### PR TITLE
Fix #53, add testpilot-ga library and sendEvent() function

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -13,9 +13,38 @@ browser.runtime.onMessage.addListener((message, source) => {
     return browser.tabs.remove(message.tabId);
   } else if (message.type === "closeTabs") {
     return closeManyTabs(message.composeTabId, message.closeTabInfo);
+  } else if (message.type === "sendEvent") {
+    delete message.type;
+    sendEvent(message);
+    return Promise.resolve(null);
   }
   console.error("Unexpected message type:", message.type);
   return null;
+});
+
+const manifest = browser.runtime.getManifest();
+
+const is_production = ! manifest.version_name.includes("dev");
+
+const ga = new TestPilotGA({
+  an: "email-tabs",
+  aid: manifest.applications.gecko.id,
+  aiid: "testpilot",
+  av: manifest.version,
+  // cd19 could also be dev or stage:
+  cd19: is_production ? "production" : "local",
+  ds: "addon",
+  tid: is_production ? "FIXME" : "", // FIXME: we need to get a GA property
+});
+
+async function sendEvent(args) {
+  ga.sendEvent(args.ec, args.ea, args);
+}
+
+sendEvent({
+  ec: "startup",
+  ea: "startup",
+  ni: true
 });
 
 async function getTabInfo(tabIds) {

--- a/addon/manifest.json.tmpl
+++ b/addon/manifest.json.tmpl
@@ -2,6 +2,7 @@
   "manifest_version": 2,
   "name": "Email Tabs",
   "version": "{{version}}",
+  "version_name": "{{version_name}}",
   "description": "{{{description}}}",
   "author": "{{{author}}}",
   "homepage_url": "{{{homepage}}}",
@@ -18,6 +19,7 @@
   },
   "background": {
     "scripts": [
+      "build/testpilot-ga.js",
       "background.js",
       "build/react.production.min.js",
       "build/react-dom-server.browser.production.min.js",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "npm-run-all": "^4.1.3",
     "stylelint": "^9.1.1",
     "stylelint-config-standard": "^18.2.0",
+    "testpilot-ga": "^0.3.0",
     "web-ext": "^2.7.0"
   },
   "homepage": "https://github.com/mozilla/email-tabs/",
@@ -42,12 +43,13 @@
     "lint:styles": "stylelint ./addon/*.css",
     "build": "npm-run-all build:*",
     "build:deps": "mkdir -p addon/build/ && cp node_modules/react/umd/react.production.min.js node_modules/react-dom/umd/react-dom.production.min.js node_modules/react-dom/umd/react-dom-server.browser.production.min.js addon/build/ && babel --retain-lines addon/popup.jsx > addon/build/popup.js && babel --retain-lines addon/emailTemplates.jsx > addon/build/emailTemplates.js",
-    "build:manifest": "node -e 'let input = JSON.parse(fs.readFileSync(\"package.json\")); input.version = input.version.slice(0, -1) + Math.floor((Date.now() - new Date(new Date().getFullYear().toString()).getTime()) / 3600000); console.log(JSON.stringify(input))' | mustache - addon/manifest.json.tmpl > addon/manifest.json",
+    "build:ga": "mkdir -p addon/build && cp $(node -e 'console.log(require.resolve(\"testpilot-ga\"))') addon/build/testpilot-ga.js",
+    "build:manifest": "node -e 'let input = JSON.parse(fs.readFileSync(\"package.json\")); input.version = input.version.slice(0, -1) + Math.floor((Date.now() - new Date(new Date().getFullYear().toString()).getTime()) / 3600000); input.version_name = `${input.version} ${process.env.NODE_ENV === \"prod\" ? \"release\" : \"dev\"}`; console.log(JSON.stringify(input))' | mustache - addon/manifest.json.tmpl > addon/manifest.json",
     "build:web-ext": "web-ext build --source-dir=addon --overwrite-dest --ignore-files '*.tmpl' --ignore-files '*.jsx'",
-    "package": "npm run build && cp web-ext-artifacts/`ls -t1 web-ext-artifacts | head -n 1` addon.xpi",
+    "package": "NODE_ENV=prod npm run build && cp web-ext-artifacts/`ls -t1 web-ext-artifacts | head -n 1` addon.xpi",
     "run": "mkdir -p ./Profile && npm run build:deps && web-ext run --source-dir=addon -p ./Profile --browser-console --keep-profile-changes -f ${FIREFOX:-nightly}",
     "test": "npm run lint",
     "postinstall": "npm run build",
-    "watch": "nodemon -e jsx -w addon/ --exec 'npm run build:deps'"
+    "watch": "nodemon -e jsx,tmpl -w addon/ --exec 'npm run build:deps'"
   }
 }


### PR DESCRIPTION
This sets version_name based on whether the add-on is built using npm run package, or run in development. Apparently Firefox doesn't support this property and complains, but I wanted to shove the dev/prod flag in the manifest somewhere, and it would complain about any additional property.