### PR TITLE
Remove unneeded permissions

### DIFF
--- a/addon/manifest.json.tmpl
+++ b/addon/manifest.json.tmpl
@@ -39,9 +39,7 @@
   "permissions": [
     "activeTab",
     "tabs",
-    "notifications",
     "clipboardWrite",
-    "storage",
     "<all_urls>"
   ]
 }


### PR DESCRIPTION
We aren't popping notifications. We used to use browser.storage, but stopped.