### PR TITLE
Fix #103, add ToC to full articles

### DIFF
--- a/addon/emailTemplates.jsx
+++ b/addon/emailTemplates.jsx
@@ -83,8 +83,22 @@ this.emailTemplates = (function () {
 
   class FullArticles extends React.Component {
     render() {
+      let toc = null;
+      if (this.props.tabs.length > 1) {
+        toc = this.props.tabs.map((tab, index) => {
+          let anchor = `email-tabs-article-${index}`;
+          tab.anchorName = anchor;
+          return <Fragment key={`toc-${index}`}><a href={`#${anchor}`}>Jump to {tab.title}</a> <br /></Fragment>;
+        });
+        toc.push(<br />);
+      }
       let tabList = this.props.tabs.map((tab, index) => {
         let selection =  null;
+        let anchorTag = null;
+        if (toc) {
+           // eslint-disable-next-line jsx-a11y/anchor-is-valid, jsx-a11y/anchor-has-content
+          anchorTag = <a name={tab.anchorName}></a>;
+        }
         if (tab.selection) {
           selection = <Fragment>{selectionDisplay(tab.selection)} <br /><br /></Fragment>;
         }
@@ -99,12 +113,16 @@ this.emailTemplates = (function () {
           readability = <Fragment><div style={{maxWidth: "600px", border: "2px solid #aaa", borderRadius: "3px", padding: "10px"}} dangerouslySetInnerHTML={{__html: content.outerHTML}} /> { hr }</Fragment>;
         }
         return <Fragment key={index}>
+          { anchorTag }
           <a href={tab.url}>{tab.title}</a> <br />
           { selection }
           { readability }
         </Fragment>;
       });
-      return <Fragment>{tabList}</Fragment>;
+      return <Fragment>
+        {toc}
+        {tabList}
+      </Fragment>;
     }
   }
 


### PR DESCRIPTION
This only triggers when more than one tab is sent. `<a name>` is more effective in email than `<x id>`.

The emails look like this:

<img width="873" alt="image" src="https://user-images.githubusercontent.com/44390/44938150-bd4a2580-ad42-11e8-939f-6d098d5e04de.png">

I put in the text "Jump to" since it's not 100% clear what each link might do. But this deserves some design review.

Arguably the first article shouldn't show up there, as it's already probably visible, and the link won't appear to do anything (it only jumps if the target isn't already on screen)