### PR TITLE
Fix #172, ask template question and start loading overlay before collecting information from tabs

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -125,7 +125,6 @@ async function sendEmail(tabIds, customDimensions) {
       loginInterrupt();
     }
   }, 1000);
-  let tabInfo = await getTabInfo(tabIds, {wantsScreenshots: true, wantsReadability: true}, customDimensions);
   await browser.tabs.executeScript(newTab.id, {
     file: "templateMetadata.js",
     runAt: "document_start",
@@ -134,6 +133,7 @@ async function sendEmail(tabIds, customDimensions) {
     file: "set-html-email.js",
     runAt: "document_start",
   });
+  let tabInfo = await getTabInfo(tabIds, {wantsScreenshots: true, wantsReadability: true}, customDimensions);
   await browser.tabs.sendMessage(newTab.id, {
     type: "sendTabInfo",
     thisTabId: newTab.id,

--- a/addon/emailTemplates.jsx
+++ b/addon/emailTemplates.jsx
@@ -192,6 +192,10 @@ this.emailTemplates = (function () {
   exports.FullArticles = FullArticles;
 
   exports.renderEmail = function(tabs, BaseComponent, copying) {
+    if (!tabs) {
+      console.trace();
+      throw new Error("Cannot renderEmail without tabs");
+    }
     let emailHtml = ReactDOMServer.renderToStaticMarkup(<BaseComponent tabs={tabs} copying={copying} />);
     let lastValue;
     while (lastValue !== emailHtml) {


### PR DESCRIPTION
Note you can still end up on the 'Preparing your email' screen for a while,
but the loading screen appears in the meantime

Also fix #114, delay creating iframe until document.body is for sure present.

This adds a new pattern for creating a promise with exposed resolve/reject,
which makes it easier to await on global information.

(This also makes everything feel noticeably snappier)