### PR TITLE
Fixing eslint warnings/errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,8 @@ module.exports = {
   },
   "plugins": [
     "jsx-a11y",
-    "mozilla"
+    "mozilla",
+    "react"
   ],
   "root": true,
   "rules": {
@@ -29,5 +30,10 @@ module.exports = {
     // them, but we aren't currently doing that.
     "jsx-a11y/label-has-associated-control": "off",
     "jsx-a11y/label-has-for": "off",
+  },
+  "settings": {
+    "react": {
+      "version": "16"
+    }
   }
 };

--- a/addon/popup.jsx
+++ b/addon/popup.jsx
@@ -293,7 +293,7 @@ class MailPreference extends React.Component {
       </div>
 
       <div className="separator"></div>
-      <p class="sorry">Sorry we don&#39;t support any other mail providers. <a href="https://github.com/mozilla/email-tabs/blob/master/docs/faq.md#frequently-asked-questions">Learn more</a></p>
+      <p className="sorry">Sorry we don&#39;t support any other mail providers. <a href="https://github.com/mozilla/email-tabs/blob/master/docs/faq.md#frequently-asked-questions">Learn more</a></p>
       {this.props.mailProvider ? footer : null}
     </div>;
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "start": "npm-run-all build run",
     "lint": "npm-run-all lint:*",
-    "lint:addon": "web-ext lint -s addon --ignore-files=build/*.js || true",
+    "lint:addon": "web-ext lint -s addon --ignore-files='build/*.js' --self-hosted || true",
     "lint:js": "eslint addon --ext=js,jsx",
     "lint:styles": "stylelint ./addon/*.css",
     "preview-templates": "http-server -c-1 .",


### PR DESCRIPTION
Circle CI is currently failing w/ the following:

```sh
> email-tabs@0.1.0 lint:js /home/circleci/project
> eslint addon --ext=js,jsx

Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration.

/home/circleci/project/addon/popup.jsx
  296:10  error  Unknown property 'class' found, use 'className' instead  react/no-unknown-property

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```

This makes it not do that. And "fixes" at least part of our `web-ext lint` woes w/ an unrelated `--self-hosted` tweak. #yolo

