### PR TITLE
Fix #22, add a context menu

### DIFF
--- a/addon/manifest.json.tmpl
+++ b/addon/manifest.json.tmpl
@@ -48,6 +48,7 @@
     "clipboardWrite",
     "notifications",
     "storage",
+    "contextMenus",
     "<all_urls>"
   ]
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -147,6 +147,27 @@ cd6,
 cd7
 ```
 
+###### When the user uses the context menu to email tabs
+
+```
+ec: interface
+ea: context-menu,
+el: email-tabs,
+cd1,
+cd2,
+cd3,
+cd6,
+cd7
+```
+
+####### If the context menu failed because no mail provider was selected
+
+```
+ec: interface,
+ea: context-menu-failed-pref,
+ni: true
+```
+
 ###### When the user is not logged in, or encounters a compose window error
 `el` will be `account` if we believe the user encountered a login form, or `error` if there's some other problem encountered.
 


### PR DESCRIPTION
If you haven't set the mail provider, this pops up a notification telling you to do so. For dumb reasons we can't open the popup.

The context menu looks like this:

<img width="214" alt="image" src="https://user-images.githubusercontent.com/44390/48583356-8240a280-e8ec-11e8-87ab-5471243a342a.png">

If you are also offended that the icon is pointing the wrong direction, then I agree.