### PR TITLE
remove updateurl and increment version

### DIFF
--- a/addon/manifest.json.tmpl
+++ b/addon/manifest.json.tmpl
@@ -13,8 +13,7 @@
   "applications": {
     "gecko": {
       "id": "email-tabs@mozilla.org",
-      "strict_min_version": "57.0a1",
-      "update_url": "https://testpilot.firefox.com/files/email-tabs@mozilla.org/updates.json"
+      "strict_min_version": "57.0a1"
     }
   },
   "background": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "email-tabs",
   "description": "Compose an email from your tabs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Mozilla Test Pilot Team (https://testpilot.firefox.com)",
   "bugs": {
     "url": "https://github.com/mozilla/email-tabs"


### PR DESCRIPTION
Looks like there is some date logic in the version when packaging the add-on, but I think this will work.